### PR TITLE
Exclusive forts

### DIFF
--- a/basic/rules.cpp
+++ b/basic/rules.cpp
@@ -232,6 +232,7 @@ static GameDefs g = {
 	0,  // REGIONS_ECONOMY
 	0, // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/fracas/rules.cpp
+++ b/fracas/rules.cpp
@@ -235,6 +235,7 @@ static GameDefs g = {
 	0,   // REGIONS_ECONOMY
 	0, // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -714,6 +714,17 @@ public:
 
 	// Combat overwhelming.
 	int OVERWHELMING;
+
+	// This setting makes buildings with defence to be exclusive in region.
+	// When enabled only one defence structure can be built in any given region.
+	// This is needed to prevent situation when there are two or more forts
+	// belonging to different factions and a battle is started... both sides would
+	// receive defense bonus... how one castle can attack another castle?
+	// No way!!
+	// It is possible to upgrade/extend stucture to bigger one. Just enter fort
+	// and start building bigger structure with the BUILD command. No downgrades
+	// are possible, structure must be destroyed first.
+	int EXCLUSIVE_FORTS;
 };
 
 extern GameDefs *Globals;

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -2657,6 +2657,15 @@ int Game::GenRules(const AString &rules, const AString &css,
 		"require more advanced resources, or odd skills to construct.   "
 		"The description of a skill will include any buildings which "
 		"it allows to be built.";
+
+	f.Paragraph(temp);
+	temp = "Forifications are special buildings as they are protecting garrison in the battle.";
+	if (Globals->EXCLUSIVE_FORTS) {
+		temp += "Just one such building can be built in the region."
+		" Fortfications are also the only buildings what are possible to upgrade into bigger buildings.";
+	}
+	temp += " When such building is built it will boost region economy and provide strategical benefits for the defenders.";
+
 	f.Paragraph(temp);
 	temp = "There are other structures that increase the maximum production "
 		"of certain items in regions";
@@ -4541,6 +4550,9 @@ int Game::GenRules(const AString &rules, const AString &css,
 	f.LinkRef("build");
 	f.TagText("h4", "BUILD");
 	f.TagText("h4", "BUILD [object type]");
+	if (Globals->EXCLUSIVE_FORTS) {
+		f.TagText("h4", "BUILD UPGRADE [object type]");
+	}
 	f.TagText("h4", "BUILD HELP [unit]");
 	temp = "BUILD given with no parameters causes the unit to perform "
 		"work on ";
@@ -4549,6 +4561,16 @@ int Game::GenRules(const AString &rules, const AString &css,
 	temp += "the object that it is currently inside.  BUILD given with an "
 		"[object type] (such as \"Tower\" or \"Galleon\") instructs "
 		"the unit to begin work on a new object of the type given. ";
+	if (Globals->EXCLUSIVE_FORTS) {
+		temp += "If region already contains any fortification then other"
+		" fortifications cannot be built there. The only way how to change them"
+		" is BUILD UPGRADE command, which will try to perform forification upgrade."
+		" It is worth to mention that [object type] must be larger structure"
+		" than currently built. Unit must be inside the structure which he wants to upgrade."
+		" It is not possible to upgrade wooden building into stone building"
+		" or stone building into rootstone building, etc.."
+		" This command is applicable only for the foritification buildings.";
+	}
 	temp += "The final form instructs the unit to assist the target unit "
 		"in its current building task, even if that task was begun "
 		"this same turn. This help will be rejected if the unit you "

--- a/havilah/rules.cpp
+++ b/havilah/rules.cpp
@@ -240,6 +240,7 @@ static GameDefs g = {
 	0,   // REGIONS_ECONOMY
 	0, // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/kingdoms/rules.cpp
+++ b/kingdoms/rules.cpp
@@ -233,6 +233,7 @@ static GameDefs g = {
 	0,   // REGIONS_ECONOMY
 	0, // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -590,12 +590,16 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 					return;
 				}
 
-				int leftToBuild = buildobj->incomplete;
-				int costDelta = ObjectDefs[currentType].cost - ObjectDefs[type].cost;
+				int buildingCost = buildobj->incomplete + ObjectDefs[currentType].cost - ObjectDefs[type].cost;
+
+				if (ObjectDefs[type].item != ObjectDefs[currentType].item) {
+					buildingCost = ObjectDefs[type].cost;
+					u->Error("Warning: because original building was built from another materials, builders started from scratch.");
+				}
 
 				buildobj = defStructure;
 				buildobj->type = type;
-				buildobj->incomplete = leftToBuild + costDelta;
+				buildobj->incomplete = buildingCost;
 			}
 		}
 	}

--- a/neworigins_v2/rules.cpp
+++ b/neworigins_v2/rules.cpp
@@ -240,6 +240,7 @@ static GameDefs g = {
 	1,   // REGIONS_ECONOMY
 	1,   // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -1572,7 +1572,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 			delete token;
 
 			if (!Globals->EXCLUSIVE_FORTS) {
-				ParseError(pCheck, unit, 0, "BUILD UPGRADE_TO command is disabled in this game.");
+				ParseError(pCheck, unit, 0, "BUILD UPGRADE command is disabled in this game.");
 				return;
 			}
 

--- a/standard/rules.cpp
+++ b/standard/rules.cpp
@@ -232,6 +232,7 @@ static GameDefs g = {
 	0,   // REGIONS_ECONOMY
 	0, // ADVANCED_TACTICS
 	0,	// OVERWHELMING
+	0,	// EXCLUSIVE_FORTS
 };
 
 GameDefs *Globals = &g;

--- a/unit.cpp
+++ b/unit.cpp
@@ -681,6 +681,7 @@ void Unit::ClearOrders()
 	routed = 0;
 	enter = 0;
 	build = 0;
+	buildUpgradeTo = 0;
 	destroy = 0;
 	if (attackorders) delete attackorders;
 	attackorders = 0;

--- a/unit.h
+++ b/unit.h
@@ -270,6 +270,8 @@ class Unit : public AListElem
 		int destroy;
 		int enter;
 		int build;
+		int buildUpgradeTo;
+
 		UnitId *promote;
 		AList findorders;
 		AList giveorders;


### PR DESCRIPTION
Adds the option to make defense structure be exclusive for each region. When enabled, the game will not allow more than one fortification structure inside each region.

The feature adds a new command `BUILD UPGRADE <Buildin name upgrade to>`, this command performs a one-way upgrade to a specified building type. To perform an upgrade, the unit must be within the upgradable structure.